### PR TITLE
feat: kafka sink should populate key from reflection

### DIFF
--- a/examples/date-kafka.yaml
+++ b/examples/date-kafka.yaml
@@ -5,4 +5,12 @@ sinks:
   - name: kafka
     config:
       brokers: localhost:9092
-      topic: test-1
+
+      # kafka topic name
+      topic: test
+
+      # Use this path to find value that will be used to set kafka key proto
+      # message.
+      # Only supports root level key at the moment
+      # Should be a string
+      key_path: ".Action"

--- a/go.mod
+++ b/go.mod
@@ -48,4 +48,5 @@ require (
 	google.golang.org/api v0.47.0
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gotest.tools/v3 v3.0.2
 )

--- a/plugins/extractors/date/date.go
+++ b/plugins/extractors/date/date.go
@@ -2,12 +2,13 @@ package date
 
 import (
 	"context"
-	"fmt"
 	"time"
+
+	"github.com/odpf/meteor/proto/odpf/meta/common"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/odpf/meteor/core/extractor"
 	"github.com/odpf/meteor/plugins"
-	"github.com/odpf/meteor/proto/odpf/meta/facets"
 )
 
 const (
@@ -42,14 +43,15 @@ func (d *Extractor) Extract(ctx context.Context, config map[string]interface{}, 
 	}
 }
 
-func (d *Extractor) Process() (*facets.Custom, error) {
+func (d *Extractor) Process() (*common.Event, error) {
 	// simulate we did some heavy workload here
 	time.Sleep(500 * time.Millisecond)
 	// ...
-
-	return &facets.Custom{CustomProperties: map[string]string{
-		"Value": fmt.Sprintf("Timestamp: %s", time.Now().String()),
-	}}, nil
+	return &common.Event{
+		Action:      "hello!",
+		Description: "sample message",
+		Timestamp:   timestamppb.New(time.Now()),
+	}, nil
 }
 
 func init() {

--- a/plugins/extractors/populate.go
+++ b/plugins/extractors/populate.go
@@ -1,5 +1,6 @@
 package extractors
 
 import (
+	_ "github.com/odpf/meteor/plugins/extractors/date"
 	_ "github.com/odpf/meteor/plugins/extractors/postgres"
 )

--- a/plugins/sinks/kafka/sink.go
+++ b/plugins/sinks/kafka/sink.go
@@ -2,6 +2,12 @@ package kafka
 
 import (
 	"context"
+	"reflect"
+	"strings"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/golang/protobuf/proto"
 	"github.com/odpf/meteor/core"
@@ -9,6 +15,10 @@ import (
 	"github.com/odpf/meteor/utils"
 	"github.com/pkg/errors"
 )
+
+type ProtoReflector interface {
+	ProtoReflect() protoreflect.Message
+}
 
 type Sink struct{}
 
@@ -18,7 +28,8 @@ func New() core.Syncer {
 
 type Config struct {
 	Brokers string `mapstructure:"brokers" validate:"required"`
-	Topic string `mapstructure:"topic" validate:"required"`
+	Topic   string `mapstructure:"topic" validate:"required"`
+	KeyPath string `mapstructure:"key_path"`
 }
 
 func (s *Sink) Sink(ctx context.Context, config map[string]interface{}, in <-chan interface{}) (err error) {
@@ -31,8 +42,9 @@ func (s *Sink) Sink(ctx context.Context, config map[string]interface{}, in <-cha
 		return errors.Wrapf(err, "failed to create kafka producer")
 	}
 	defer producer.Flush(5000)
+
 	for val := range in {
-		if err := s.push(producer, val, kafkaConf.Topic); err != nil {
+		if err := s.push(producer, kafkaConf, val); err != nil {
 			return err
 		}
 	}
@@ -46,20 +58,100 @@ func getProducer(brokers string) (*kafka.Producer, error) {
 	return kafka.NewProducer(producerConf)
 }
 
-func (s *Sink) push(producer *kafka.Producer, value interface{}, topic string) error {
-	protoBytes, err := proto.Marshal(value.(proto.Message))
-	if err != nil {
-		return errors.Wrap(err, "failed to serialize payload as a protobuf message")
-	}
-
-	err = producer.Produce(&kafka.Message{
-		TopicPartition: kafka.TopicPartition{Topic: &topic},
-		Value:          protoBytes,
-	}, nil)
+func (s *Sink) push(producer *kafka.Producer, conf *Config, payload interface{}) error {
+	kafkaValue, err := s.buildValue(payload)
 	if err != nil {
 		return err
 	}
-	return nil
+
+	kafkaKey, err := s.buildKey(payload, conf.KeyPath)
+	if err != nil {
+		return err
+	}
+
+	return producer.Produce(&kafka.Message{
+		TopicPartition: kafka.TopicPartition{Topic: &conf.Topic},
+		Key:            kafkaKey,
+		Value:          kafkaValue,
+	}, nil)
+}
+
+func (s *Sink) buildValue(value interface{}) ([]byte, error) {
+	protoBytes, err := proto.Marshal(value.(proto.Message))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to serialize payload as a protobuf message")
+	}
+	return protoBytes, nil
+}
+
+// we can optimize this by caching descriptor and key path
+func (s *Sink) buildKey(payload interface{}, keyPath string) ([]byte, error) {
+	if keyPath == "" {
+		return nil, nil
+	}
+
+	// extract key field name and value
+	fieldName, err := s.getTopLevelKeyFromPath(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	keyString, keyJsonName, err := s.extractKeyFromPayload(fieldName, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	// get descriptor
+	reflector, ok := payload.(ProtoReflector)
+	if !ok {
+		return nil, errors.New("not a valid proto payload")
+	}
+	messageDescriptor := reflector.ProtoReflect().Descriptor()
+	fieldDescriptor := messageDescriptor.Fields().ByJSONName(keyJsonName)
+	if fieldDescriptor == nil {
+		return nil, errors.New("failed to build kafka key")
+	}
+
+	// populate message
+	dynamicMsgKey := dynamicpb.NewMessage(messageDescriptor)
+	dynamicMsgKey.Set(fieldDescriptor, protoreflect.ValueOfString(keyString))
+	return proto.Marshal(dynamicMsgKey)
+}
+
+func (s *Sink) extractKeyFromPayload(fieldName string, value interface{}) (string, string, error) {
+	valueOf := reflect.ValueOf(value)
+	if valueOf.Kind() == reflect.Ptr {
+		valueOf = valueOf.Elem()
+	}
+	if valueOf.Kind() != reflect.Struct {
+		return "", "", errors.New("invalid data")
+	}
+
+	structField, ok := valueOf.Type().FieldByName(fieldName)
+	if !ok {
+		return "", "", errors.New("invalid path, unknown field")
+	}
+	jsonName := strings.Split(structField.Tag.Get("json"), ",")[0]
+
+	fieldVal := valueOf.FieldByName(fieldName)
+	if !fieldVal.IsValid() || fieldVal.IsZero() {
+		return "", "", errors.New("invalid path, unknown field")
+	}
+	if fieldVal.Type().Kind() != reflect.String {
+		return "", "", errors.Errorf("unsupported key type, should be string found: %s", fieldVal.Type().String())
+	}
+
+	return fieldVal.String(), jsonName, nil
+}
+
+func (s *Sink) getTopLevelKeyFromPath(keyPath string) (string, error) {
+	keyPaths := strings.Split(keyPath, ".")
+	if len(keyPaths) < 2 {
+		return "", errors.New("invalid path, require at least one field name e.g.: .URN")
+	}
+	if len(keyPaths) > 2 {
+		return "", errors.New("invalid path, doesn't support nested field names yet")
+	}
+	return keyPaths[1], nil
 }
 
 func init() {


### PR DESCRIPTION
- protobuf used to create the value will be used to generate the kafka key

```
name: date-kafka-recipe
source:
  type: date
sinks:
  - name: kafka
    config:
      brokers: localhost:9092

      # kafka topic name
      topic: test-3

      # Use this path to find value that will be used to set kafka key proto
      # message.
      # Only supports root level key at the moment
      # Should be a string
      key_path: ".Action"
```
