### PR TITLE
fix(postgres): missing import of pq driver

### DIFF
--- a/plugins/extractors/postgres/postgres.go
+++ b/plugins/extractors/postgres/postgres.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	// used to register the postgres driver
+	_ "github.com/lib/pq"
 	"github.com/odpf/meteor/models"
 	commonv1beta1 "github.com/odpf/meteor/models/odpf/assets/common/v1beta1"
 	facetsv1beta1 "github.com/odpf/meteor/models/odpf/assets/facets/v1beta1"


### PR DESCRIPTION
While testing it for other issue, noticed that the import was missing in `postgres.go`.

Thus it kept throwing the following error on run:
`ERRO[0000] error running recipe                          duration_ms=0 err="failed to setup extractor: could not initiate extractor \"postgres\": failed to create connection: sql: unknown driver \"postgres\" (forgotten import?)" recipe=sample records_count=0`