### PR TITLE
fix: go-ora connection_url fix and removed redundant connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/ory/dockertest/v3 v3.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/segmentio/kafka-go v0.4.17
-	github.com/sijms/go-ora/v2 v2.2.20
+	github.com/sijms/go-ora/v2 v2.2.22
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -910,6 +910,8 @@ github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJ
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sijms/go-ora/v2 v2.2.20 h1:fhB7hLEtJZ3WEsbG2JVXOyoo2zZFstP0sWon6CAUvRM=
 github.com/sijms/go-ora/v2 v2.2.20/go.mod h1:jzfAFD+4CXHE+LjGWFl6cPrtiIpQVxakI2gvrMF2w6Y=
+github.com/sijms/go-ora/v2 v2.2.22 h1:XmJAEwgokgLfe43QZtYWi6+ziYKz4yHmqKQlbdNVFmA=
+github.com/sijms/go-ora/v2 v2.2.22/go.mod h1:jzfAFD+4CXHE+LjGWFl6cPrtiIpQVxakI2gvrMF2w6Y=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/plugins/extractors/oracle/README.md
+++ b/plugins/extractors/oracle/README.md
@@ -6,14 +6,14 @@
 source:
   type: oracle
   config:
-    connection_url: admin/1234@localhost:1521/xe
+    connection_url: oracle://admin:1234@localhost:1521/xe
 ```
 
 ## Inputs
 
 | Key | Value | Example | Description |    |
 | :-- | :---- | :------ | :---------- | :- |
-| `connection_url` | `string` | `admin/1234@localhost:1521/xe` | Connection String to access Oracle Database | *required* |
+| `connection_url` | `string` | `oracle://admin:1234@localhost:1521/xe` | Connection String to access Oracle Database | *required* |
 
 ## Outputs
 

--- a/plugins/extractors/oracle/oracle_test.go
+++ b/plugins/extractors/oracle/oracle_test.go
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 
 	// Exponential backoff-retry for container to be resy to accept connections
 	retryFn := func(r *dockertest.Resource) (err error) {
-		db, err = sql.Open("godror", fmt.Sprintf("%s/%s@%s/%s", sysUser, password, host, defaultDB))
+		db, err = sql.Open("oracle", fmt.Sprintf("oracle://%s:%s@%s/%s", sysUser, password, host, defaultDB))
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func TestExtract(t *testing.T) {
 		extr := oracle.New(utils.Logger)
 
 		err := extr.Init(ctx, map[string]interface{}{
-			"connection_url": fmt.Sprintf("%s/%s@%s/%s", user, password, host, defaultDB),
+			"connection_url": fmt.Sprintf("oracle://%s:%s@%s/%s", user, password, host, defaultDB),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -115,7 +115,7 @@ func setup() (err error) {
 	}
 	err = execute(db, queries)
 
-	userDB, err := sql.Open("godror", fmt.Sprintf("%s/%s@%s/%s", user, password, host, defaultDB))
+	userDB, err := sql.Open("oracle", fmt.Sprintf("oracle://%s:%s@%s/%s", user, password, host, defaultDB))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The connection string is slightly different for go-ora, so fixed that and also one extra connection to DB was created, also resolved that issue. 
The oracle test is now passing.
```
PASS 
ok      github.com/odpf/meteor/plugins/extractors/oracle        347.267s
```