### PR TITLE
feat: fallback to filename if recipe name is missing

### DIFF
--- a/recipe/generator.go
+++ b/recipe/generator.go
@@ -46,6 +46,10 @@ func outputRecipe(tmplt *template.Template, outputDir string, data TemplateData)
 	}
 	defer file.Close()
 
+	if data.Data["name"] == nil {
+		data.Data["name"] = data.FileName
+	}
+
 	if err := tmplt.Execute(file, data); err != nil {
 		return fmt.Errorf("error executing template: %w", err)
 	}

--- a/recipe/generator_test.go
+++ b/recipe/generator_test.go
@@ -14,41 +14,74 @@ func TestFromTemplate(t *testing.T) {
 	t.Run("should output recipe files using template to output directory", func(t *testing.T) {
 		templatePath := "./testdata/generator/template.yaml"
 		outputDir := "./testdata/generator/temp"
-		data := []recipe.TemplateData{
-			{
-				FileName: "recipe-1",
-				Data: map[string]interface{}{
-					"broker": "main-broker.com:9092",
-					"owner":  "john@example.com",
-				},
-			},
-			{
-				FileName: "recipe-2",
-				Data: map[string]interface{}{
-					"broker": "secondary-broker.com:9092",
-					"owner":  "jane@example.com",
-				},
-			},
-		}
 
-		cleanDir(t, outputDir)
-		defer cleanDir(t, outputDir)
+		t.Run("when recipe has a name", func(t *testing.T) {
+			data := []recipe.TemplateData{
+				{
+					FileName: "recipe-one",
+					Data: map[string]interface{}{
+						"name":   "recipe-1",
+						"broker": "main-broker.com:9092",
+						"owner":  "john@example.com",
+					},
+				},
+				{
+					FileName: "recipe-two",
+					Data: map[string]interface{}{
+						"name":   "recipe-2",
+						"broker": "secondary-broker.com:9092",
+						"owner":  "jane@example.com",
+					},
+				},
+			}
 
-		err := recipe.FromTemplate(recipe.TemplateConfig{
-			TemplateFilePath: templatePath,
-			OutputDirPath:    outputDir,
-			Data:             data,
+			cleanDir(t, outputDir)
+			defer cleanDir(t, outputDir)
+
+			err := recipe.FromTemplate(recipe.TemplateConfig{
+				TemplateFilePath: templatePath,
+				OutputDirPath:    outputDir,
+				Data:             data,
+			})
+			require.NoError(t, err)
+
+			assertRecipeFile(t,
+				"./testdata/generator/expected.yaml",
+				path.Join(outputDir, data[0].FileName+".yaml"),
+			)
+			assertRecipeFile(t,
+				"./testdata/generator/expected-2.yaml",
+				path.Join(outputDir, data[1].FileName+".yaml"),
+			)
 		})
-		require.NoError(t, err)
 
-		assertRecipeFile(t,
-			"./testdata/generator/expected.yaml",
-			path.Join(outputDir, data[0].FileName+".yaml"),
-		)
-		assertRecipeFile(t,
-			"./testdata/generator/expected-2.yaml",
-			path.Join(outputDir, data[1].FileName+".yaml"),
-		)
+		t.Run("when recipe does not have a name", func(t *testing.T) {
+			data := []recipe.TemplateData{
+				{
+					FileName: "recipe-three",
+					Data: map[string]interface{}{
+						"broker": "main-broker.com:9092",
+						"owner":  "john@example.com",
+					},
+				},
+			}
+
+			cleanDir(t, outputDir)
+			defer cleanDir(t, outputDir)
+
+			err := recipe.FromTemplate(recipe.TemplateConfig{
+				TemplateFilePath: templatePath,
+				OutputDirPath:    outputDir,
+				Data:             data,
+			})
+			require.NoError(t, err)
+
+			assertRecipeFile(t,
+				"./testdata/generator/expected-3.yaml",
+				path.Join(outputDir, data[0].FileName+".yaml"),
+			)
+		})
+
 	})
 }
 

--- a/recipe/generator_test.go
+++ b/recipe/generator_test.go
@@ -1,6 +1,8 @@
 package recipe_test
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -8,6 +10,7 @@ import (
 	"github.com/odpf/meteor/recipe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestFromTemplate(t *testing.T) {
@@ -16,29 +19,22 @@ func TestFromTemplate(t *testing.T) {
 		outputDir := "./testdata/generator/temp"
 
 		t.Run("when recipe has a name", func(t *testing.T) {
-			data := []recipe.TemplateData{
-				{
-					FileName: "recipe-one",
-					Data: map[string]interface{}{
-						"name":   "recipe-1",
-						"broker": "main-broker.com:9092",
-						"owner":  "john@example.com",
-					},
-				},
-				{
-					FileName: "recipe-two",
-					Data: map[string]interface{}{
-						"name":   "recipe-2",
-						"broker": "secondary-broker.com:9092",
-						"owner":  "jane@example.com",
-					},
-				},
+			bytes, err := ioutil.ReadFile("./testdata/generator/data-1-2.yaml")
+			if err != nil {
+				fmt.Println(fmt.Errorf("error reading data: %w", err))
+				return
+			}
+
+			var data []recipe.TemplateData
+			if err := yaml.Unmarshal(bytes, &data); err != nil {
+				fmt.Println(fmt.Errorf("error parsing data: %w", err))
+				return
 			}
 
 			cleanDir(t, outputDir)
 			defer cleanDir(t, outputDir)
 
-			err := recipe.FromTemplate(recipe.TemplateConfig{
+			err = recipe.FromTemplate(recipe.TemplateConfig{
 				TemplateFilePath: templatePath,
 				OutputDirPath:    outputDir,
 				Data:             data,
@@ -56,20 +52,22 @@ func TestFromTemplate(t *testing.T) {
 		})
 
 		t.Run("when recipe does not have a name", func(t *testing.T) {
-			data := []recipe.TemplateData{
-				{
-					FileName: "recipe-three",
-					Data: map[string]interface{}{
-						"broker": "main-broker.com:9092",
-						"owner":  "john@example.com",
-					},
-				},
+			bytes, err := ioutil.ReadFile("./testdata/generator/data-3.yaml")
+			if err != nil {
+				fmt.Println(fmt.Errorf("error reading data: %w", err))
+				return
+			}
+
+			var data []recipe.TemplateData
+			if err := yaml.Unmarshal(bytes, &data); err != nil {
+				fmt.Println(fmt.Errorf("error parsing data: %w", err))
+				return
 			}
 
 			cleanDir(t, outputDir)
 			defer cleanDir(t, outputDir)
 
-			err := recipe.FromTemplate(recipe.TemplateConfig{
+			err = recipe.FromTemplate(recipe.TemplateConfig{
 				TemplateFilePath: templatePath,
 				OutputDirPath:    outputDir,
 				Data:             data,

--- a/recipe/reader.go
+++ b/recipe/reader.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"gopkg.in/yaml.v3"
@@ -60,6 +61,12 @@ func (r *Reader) readFile(path string) (recipe Recipe, err error) {
 	err = yaml.Unmarshal(buff.Bytes(), &node)
 	if err != nil {
 		return
+	}
+
+	if node.Name.Value == "" {
+		file := filepath.Base(path)
+		fileName := strings.TrimSuffix(file, filepath.Ext(file))
+		node.Name.Value = fileName
 	}
 
 	recipe, err = node.toRecipe()

--- a/recipe/reader_test.go
+++ b/recipe/reader_test.go
@@ -24,33 +24,65 @@ func TestReaderRead(t *testing.T) {
 	})
 
 	t.Run("should return recipe from a path given in parameter", func(t *testing.T) {
-		reader := recipe.NewReader()
+		t.Run("where recipe has a name", func(t *testing.T) {
+			reader := recipe.NewReader()
 
-		recipes, err := reader.Read("./testdata/testdir/test-recipe.yaml")
-		if err != nil {
-			t.Fatal(err)
-		}
-		expectedRecipes := []recipe.Recipe{
-			{
-				Name: "test-recipe",
-				Source: recipe.PluginRecipe{
-					Name: "test-source",
-					Config: map[string]interface{}{
-						"foo": "bar",
+			recipes, err := reader.Read("./testdata/testdir/test-recipe.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			expectedRecipes := []recipe.Recipe{
+				{
+					Name: "test-recipe",
+					Source: recipe.PluginRecipe{
+						Name: "test-source",
+						Config: map[string]interface{}{
+							"foo": "bar",
+						},
 					},
-				},
-				Sinks: []recipe.PluginRecipe{
-					{
-						Name:   "test-sink",
-						Config: map[string]interface{}{},
+					Sinks: []recipe.PluginRecipe{
+						{
+							Name:   "test-sink",
+							Config: map[string]interface{}{},
+						},
 					},
-				},
-			}}
+				}}
 
-		assert.Len(t, recipes, len(expectedRecipes))
-		for i, r := range recipes {
-			compareRecipes(t, expectedRecipes[i], r)
-		}
+			assert.Len(t, recipes, len(expectedRecipes))
+			for i, r := range recipes {
+				compareRecipes(t, expectedRecipes[i], r)
+			}
+		})
+
+		t.Run("where recipe does not have a name", func(t *testing.T) {
+			reader := recipe.NewReader()
+
+			recipes, err := reader.Read("./testdata/testdir/test-recipe-no-name.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			expectedRecipes := []recipe.Recipe{
+				{
+					Name: "test-recipe-no-name",
+					Source: recipe.PluginRecipe{
+						Name: "test-source",
+						Config: map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+					Sinks: []recipe.PluginRecipe{
+						{
+							Name:   "test-sink",
+							Config: map[string]interface{}{},
+						},
+					},
+				}}
+
+			assert.Len(t, recipes, len(expectedRecipes))
+			for i, r := range recipes {
+				compareRecipes(t, expectedRecipes[i], r)
+			}
+		})
 	})
 
 	t.Run("should parse variable in recipe with value from env vars prefixed with METEOR_", func(t *testing.T) {
@@ -130,6 +162,21 @@ func TestReaderRead(t *testing.T) {
 			t.Fatal(err)
 		}
 		expected := []recipe.Recipe{
+			{
+				Name: "test-recipe-no-name",
+				Source: recipe.PluginRecipe{
+					Name: "test-source",
+					Config: map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+				Sinks: []recipe.PluginRecipe{
+					{
+						Name:   "test-sink",
+						Config: map[string]interface{}{},
+					},
+				},
+			},
 			{
 				Name: "test-recipe",
 				Source: recipe.PluginRecipe{

--- a/recipe/testdata/generator/data-1-2.yaml
+++ b/recipe/testdata/generator/data-1-2.yaml
@@ -1,0 +1,10 @@
+- FileName: recipe-one
+  Data:
+    name: recipe-1
+    broker: main-broker.com:9092
+    owner: john@example.com
+- FileName: recipe-two
+  Data:
+    name: recipe-2
+    broker: secondary-broker.com:9092
+    owner: jane@example.com

--- a/recipe/testdata/generator/data-3.yaml
+++ b/recipe/testdata/generator/data-3.yaml
@@ -1,0 +1,4 @@
+- FileName: recipe-three
+  Data:
+    broker: main-broker.com:9092
+    owner: john@example.com

--- a/recipe/testdata/generator/expected-3.yaml
+++ b/recipe/testdata/generator/expected-3.yaml
@@ -1,0 +1,12 @@
+name: recipe-three
+source:
+  type: kafka
+  config:
+    broker: "main-broker.com:9092"
+sinks:
+  - name: console
+processors:
+  - name: enrich
+    config:
+      host:  main-broker.com:9092
+      owner:  john@example.com

--- a/recipe/testdata/generator/template.yaml
+++ b/recipe/testdata/generator/template.yaml
@@ -1,4 +1,4 @@
-name: {{ .FileName }}
+name: {{ .Data.name }}
 source:
   type: kafka
   config:

--- a/recipe/testdata/testdir/test-recipe-no-name.yaml
+++ b/recipe/testdata/testdir/test-recipe-no-name.yaml
@@ -1,0 +1,6 @@
+source:
+  name: test-source
+  config:
+    foo: bar
+sinks:
+  - name: test-sink


### PR DESCRIPTION
When using the `gen` command, if `name` is not mentioned in `data`, it will fall back to the `FileName` as the recipe's name.