### PR TITLE
feat(optimus): expose configuring grpc max receive size

### DIFF
--- a/plugins/extractors/optimus/README.md
+++ b/plugins/extractors/optimus/README.md
@@ -14,6 +14,7 @@ source:
 | Key | Value | Example | Description |    |
 | :-- | :---- | :------ | :---------- | :- |
 | `host` | `string` | `optimus.com:80` | Optimus' GRPC host | *required* |
+| `max_size_in_mb` | `int` | `45` | Max megabytes for GRPC client to receive message. Default to 45. |  |
 
 ## Outputs
 

--- a/plugins/extractors/optimus/optimus.go
+++ b/plugins/extractors/optimus/optimus.go
@@ -23,7 +23,8 @@ var summary string
 
 // Config holds the set of configuration for the bigquery extractor
 type Config struct {
-	Host string `mapstructure:"host" validate:"required"`
+	Host        string `mapstructure:"host" validate:"required"`
+	MaxSizeInMB int    `mapstructure:"max_size_in_mb"`
 }
 
 var sampleConfig = `
@@ -64,7 +65,7 @@ func (e *Extractor) Init(ctx context.Context, configMap map[string]interface{}) 
 		return plugins.InvalidConfigError{}
 	}
 
-	if err := e.client.Connect(ctx, e.config.Host); err != nil {
+	if err := e.client.Connect(ctx, e.config.Host, e.config.MaxSizeInMB); err != nil {
 		return errors.Wrap(err, "error connecting to host")
 	}
 

--- a/plugins/extractors/optimus/optimus_test.go
+++ b/plugins/extractors/optimus/optimus_test.go
@@ -38,7 +38,7 @@ func TestInit(t *testing.T) {
 		ctx := context.TODO()
 
 		client := new(mockClient)
-		client.On("Connect", ctx, validConfig["host"]).Return(nil)
+		client.On("Connect", ctx, validConfig["host"], 0).Return(nil)
 		defer client.AssertExpectations(t)
 
 		extr := optimus.New(testutils.Logger, client)
@@ -78,8 +78,8 @@ type mockClient struct {
 	mock.Mock
 }
 
-func (c *mockClient) Connect(ctx context.Context, host string) (err error) {
-	args := c.Called(ctx, host)
+func (c *mockClient) Connect(ctx context.Context, host string, maxSizeInMB int) (err error) {
+	args := c.Called(ctx, host, maxSizeInMB)
 
 	return args.Error(0)
 }
@@ -118,7 +118,7 @@ func (c *mockClient) GetJobTask(
 }
 
 func setupExtractExpectation(ctx context.Context, client *mockClient) {
-	client.On("Connect", ctx, validConfig["host"]).Return(nil).Once()
+	client.On("Connect", ctx, validConfig["host"], 0).Return(nil).Once()
 
 	client.On("ListProjects", ctx, &pb.ListProjectsRequest{}, mock.Anything).Return(&pb.ListProjectsResponse{
 		Projects: []*pb.ProjectSpecification{


### PR DESCRIPTION
new `max_size_in_mb1` in `optimus` extractor to set max megabytes for GRPC client to receive message.
```
source:
  name: optimus
  config:
    host: optimus.com
    max_size_in_mb: 100
```
