### PR TITLE
feat: allow disabling sink retries

### DIFF
--- a/agent/retrier.go
+++ b/agent/retrier.go
@@ -9,7 +9,6 @@ import (
 )
 
 const (
-	defaultMaxRetries      = 5
 	defaultInitialInterval = 5 * time.Second
 )
 
@@ -19,18 +18,16 @@ type retrier struct {
 }
 
 func newRetrier(maxRetries int, initialInterval time.Duration) *retrier {
-	r := new(retrier)
-
-	r.maxRetries = maxRetries
-	if r.maxRetries == 0 {
-		r.maxRetries = defaultMaxRetries
+	r := retrier{
+		maxRetries:      maxRetries,
+		initialInterval: initialInterval,
 	}
-	r.initialInterval = initialInterval
+
 	if r.initialInterval == 0 {
 		r.initialInterval = defaultInitialInterval
 	}
 
-	return r
+	return &r
 }
 
 func (r *retrier) retry(operation func() error, notify func(e error, d time.Duration)) error {


### PR DESCRIPTION
If 0 retry is specified via configuration file, do not override it with
default of 5. Only if the configuration is skipped, default to 5.

Example 1 - meteor.yml:

    LOG_LEVEL: info
    MAX_RETRIES: 5

retries = 5.

Example 2 - meteor.yml:

    LOG_LEVEL: info
    MAX_RETRIES: 0

retries = 0.

Example 3 - meteor.yml:

    LOG_LEVEL: info

retries = 5.