### PR TITLE
fix: respect context cancellation for sink retries

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -255,7 +255,7 @@ func (r *Agent) setupSink(ctx context.Context, sr recipe.PluginRecipe, stream *s
 		)
 	}
 	stream.subscribe(func(records []models.Record) error {
-		err := r.retrier.retry(func() error {
+		err := r.retrier.retry(ctx, func() error {
 			err := sink.Sink(ctx, records)
 			return err
 		}, retryNotification)

--- a/agent/retrier.go
+++ b/agent/retrier.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -30,8 +31,9 @@ func newRetrier(maxRetries int, initialInterval time.Duration) *retrier {
 	return &r
 }
 
-func (r *retrier) retry(operation func() error, notify func(e error, d time.Duration)) error {
+func (r *retrier) retry(ctx context.Context, operation func() error, notify func(e error, d time.Duration)) error {
 	bo := backoff.WithMaxRetries(r.createExponentialBackoff(r.initialInterval), uint64(r.maxRetries))
+	bo = backoff.WithContext(bo, ctx)
 	return backoff.RetryNotify(func() error {
 		err := operation()
 		if err == nil {

--- a/test/utils/arg_matcher.go
+++ b/test/utils/arg_matcher.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type ArgMatcher interface{ Matches(interface{}) bool }
+
+func OfTypeContext() ArgMatcher {
+	return mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })
+}


### PR DESCRIPTION
If the context is cancelled, no further retries would be attempted for
sink of records. This would ensure that meteor respects the termination
signal and gracefully shuts down running recipes without waiting for
pending retries to be attempted.

Closes #401. 