### PR TITLE
fix(lint): format error message with appropriate line breaks

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -124,7 +124,7 @@ func printLintErrors(errs []error, rcp recipe.Recipe) {
 			printConfigErrors(rcp, invalidConfigError)
 			continue
 		}
-		fmt.Printf("recipe error: %s", err.Error())
+		fmt.Printf("recipe error: %s\n", err.Error())
 	}
 }
 


### PR DESCRIPTION
Before

```
$ meteor lint recipe.yaml
recipe error: urn scope is required to generate unique urnsample: invalid http sink config: Key: 'Config.method' Error:Field validation for 'method' failed on the 'required' tag
sample: invalid labels processor config: Key: 'Config.labels' Error:Field validation for 'labels' failed on the 'required' tag

Some checks were not successful
1 failing, 0 successful, and 1 total

✘  sample	(3 errors, 0 warnings)
```

After

```
$ meteor lint recipe.yaml
recipe error: urn scope is required to generate unique urn
sample: invalid http sink config: Key: 'Config.method' Error:Field validation for 'method' failed on the 'required' tag

Some checks were not successful
1 failing, 0 successful, and 1 total

✘  sample	(2 errors, 0 warnings)
```