### PR TITLE
fix: accept and use scope for generating recipe

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -30,6 +30,7 @@ func NewCmd() *cobra.Command {
 func NewRecipeCmd() *cobra.Command {
 	var (
 		extractor  string
+		scope      string
 		sinks      string
 		processors string
 	)
@@ -88,13 +89,24 @@ func NewRecipeCmd() *cobra.Command {
 				}
 			}
 
-			return generator.Recipe(args[0], extractor, sinkList, procList)
+			return generator.Recipe(generator.RecipeParams{
+				Name:       args[0],
+				Source:     extractor,
+				Scope:      scope,
+				Sinks:      sinkList,
+				Processors: procList,
+			})
 		},
 	}
 
 	cmd.Flags().StringVarP(&extractor, "extractor", "e", "", "Type of extractor")
+	cmd.Flags().StringVarP(&scope, "scope", "n", "", "URN's namespace")
 	cmd.Flags().StringVarP(&sinks, "sinks", "s", "", "List of sink types")
 	cmd.Flags().StringVarP(&processors, "processors", "p", "", "List of processor types")
+
+	if err := cmd.MarkFlagRequired("scope"); err != nil {
+		panic(err)
+	}
 
 	return cmd
 

--- a/generator/recipe.yaml
+++ b/generator/recipe.yaml
@@ -1,9 +1,10 @@
 name: {{.Name}}
 version: {{.Version}}
 source:
-{{- range $key, $value := .Source }}
-  type: {{$key}}
-  config: {{$value | indent 4}}
+{{- with .Source }}
+  name: {{.Name}}
+  scope: {{.Scope}}
+  config: {{.SampleConfig | indent 4}}
 {{- end }}
 {{- if ne (len .Sinks) 0 }}
 sinks:


### PR DESCRIPTION
Add new mandatory flag --scope to 'meteor new recipe' command for
creating a sample recipe and use the provided scope for generating the
recipe.

BREAKING CHANGE: Method signature for generator.Recipe() changed.

Closes #402.