### PR TITLE
fix: improve error messages

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -111,7 +111,7 @@ func RunCmd() *cobra.Command {
 				lg.Debug("recipe details", "recipe", run.Recipe)
 				var row []string
 				if run.Error != nil {
-					lg.Error(run.Error.Error(), "recipe")
+					lg.Error(run.Error.Error(), "recipe", run.Recipe.Name)
 					failures++
 					row = append(row, cs.FailureIcon(), run.Recipe.Name, cs.Grey(run.Recipe.Source.Name), cs.Greyf("%v ms", strconv.Itoa(run.DurationInMs)), cs.Greyf(strconv.Itoa(run.RecordCount)))
 				} else {

--- a/plugins/errors.go
+++ b/plugins/errors.go
@@ -3,11 +3,10 @@ package plugins
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
-var (
-	ErrEmptyURNScope = errors.New("urn scope is required to generate unique urn")
-)
+var ErrEmptyURNScope = errors.New("urn scope is required to generate unique urn")
 
 // ConfigError contains fields to check error
 type ConfigError struct {
@@ -23,7 +22,20 @@ type InvalidConfigError struct {
 }
 
 func (err InvalidConfigError) Error() string {
-	return fmt.Sprintf("invalid %s config", err.Type)
+	ss := make([]string, 0, len(err.Errors))
+	for _, e := range err.Errors {
+		ss = append(ss, e.Message)
+	}
+
+	var details string
+	if len(ss) != 0 {
+		details = ":\n\t * " + strings.Join(ss, "\n\t * ")
+	}
+
+	if err.Type == "" {
+		return "invalid config" + details
+	}
+	return fmt.Sprintf("invalid %s config", err.Type) + details
 }
 
 func (err InvalidConfigError) HasError() bool {

--- a/plugins/errors_test.go
+++ b/plugins/errors_test.go
@@ -1,0 +1,60 @@
+//go:build plugins
+// +build plugins
+
+package plugins
+
+import (
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvalidConfigError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      InvalidConfigError
+		expected string
+	}{
+		{
+			name: "WithType",
+			err: InvalidConfigError{
+				Type:       "extractor",
+				PluginName: "caramlstore",
+				Errors: []ConfigError{
+					{Key: "engine", Message: "validation for field 'engine' failed on the 'oneof' tag"},
+					{Key: "script", Message: "validation for field 'script' failed on the 'required' tag"},
+				},
+			},
+			expected: heredoc.Doc(`
+				invalid extractor config:
+					 * validation for field 'engine' failed on the 'oneof' tag
+					 * validation for field 'script' failed on the 'required' tag`),
+		},
+		{
+			name: "WithoutType",
+			err: InvalidConfigError{
+				PluginName: "caramlstore",
+				Errors: []ConfigError{
+					{Key: "engine", Message: "validation for field 'engine' failed on the 'oneof' tag"},
+				},
+			},
+			expected: heredoc.Doc(`
+				invalid config:
+					 * validation for field 'engine' failed on the 'oneof' tag`),
+		},
+		{
+			name: "WithoutErrors",
+			err: InvalidConfigError{
+				Type:       "extractor",
+				PluginName: "caramlstore",
+			},
+			expected: "invalid extractor config",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.err.Error())
+		})
+	}
+}

--- a/plugins/util.go
+++ b/plugins/util.go
@@ -53,10 +53,9 @@ func buildConfig(configMap map[string]interface{}, c interface{}) (err error) {
 	if errors.As(err, &validationErr) {
 		var configErrors []ConfigError
 		for _, fieldErr := range validationErr {
-			key := strings.TrimPrefix(fieldErr.Namespace(), "Config.")
 			configErrors = append(configErrors, ConfigError{
-				Key:     key,
-				Message: fieldErr.Error(),
+				Key:     fieldErr.Field(),
+				Message: fmt.Sprintf("validation for field '%s' failed on the '%s' tag", fieldErr.Field(), fieldErr.Tag()),
 			})
 		}
 		return InvalidConfigError{


### PR DESCRIPTION
- Include plugin name in the error message when it is not found.
- Include the validation failure message along with the line number in
  the error message for plugin config.
- During lint, include the recipe name while printing errors that are 
  neither 'not found' nor 'invalid config' errors.
- During run, on run failure, include recipe name in the error log 
  context.
- Include details of the validation failures in the error message for
  InvalidConfigError. This gets printed while trying to run the recipe.

BEFORE:

    $ meteor run run ./_recipes/caramlstore-stg-wth-script-invalid.yaml
    INFO[0000] running recipe                                recipe=caramlstore-stg-wth-script-invalid
    ERRO[0000] error running recipe                          duration_ms=189 err="failed to setup processor: could not initiate processor \"script\": script processor init: invalid  config" recipe=caramlstore-stg-wth-script-invalid records_count=0
    ERRO[0000] failed to setup processor: could not initiate processor "script": script processor init: invalid  config
    ...

    $ meteor lint ./_recipes
    caramlstore-stg-wth-script-invalid: invalid script processor config on line: 13
    caramlstore-stg-wth-script-invalid: invalid script processor config: Key: 'Config.script' Error:Field validation for 'script' failed on the 'required' tag
    recipe error: urn scope is required to generate unique urn
    kafka-to-http: invalid labels processor config: Key: 'Config.labels' Error:Field validation for 'labels' failed on the 'required' tag
    service_yaml-test: invalid extractor on line: 4
    shield-integration: invalid shield extractor config: Key: 'Config.host' Error:Field validation for 'host' failed on the 'required' tag
    ...

AFTER:

    $ meteor run run ./_recipes/caramlstore-stg-wth-script-invalid.yaml
    INFO[0000] running recipe                                recipe=caramlstore-stg-wth-script-invalid
    ERRO[0000] error running recipe                          duration_ms=205 err="failed to setup processor: could not initiate processor \"script\": script processor init: invalid config:     * validation for field 'engine' failed on the 'oneof' tag\n\t * validation for field 'script' failed on the 'required' tag" recipe=caramlstore-stg-wth-script-invalid records_count=0
    ERRO[0000] failed to setup processor: could not initiate processor "script": script processor init: invalid config:
         * validation for field 'engine' failed on the 'oneof' tag
         * validation for field 'script' failed on the 'required' tag  recipe=caramlstore-stg-wth-script-invalid
    ...

    $ meteor lint ./_recipes
    caramlstore-stg-wth-script-invalid: invalid script processor config on line: 13: validation for field 'engine' failed on the 'oneof' tag
    caramlstore-stg-wth-script-invalid: invalid script processor config: validation for field 'script' failed on the 'required' tag
    kafka-to-http: recipe error: urn scope is required to generate unique urn
    kafka-to-http: invalid labels processor config: validation for field 'labels' failed on the 'required' tag
    service_yaml-test: invalid 'service_yaml' extractor on line: 4
    shield-integration: invalid shield extractor config: validation for field 'host' failed on the 'required' tag
Closes #416