### PR TITLE
fix: skip validation for recipe scope if unneeded

### DIFF
--- a/generator/recipe.yaml
+++ b/generator/recipe.yaml
@@ -3,7 +3,9 @@ version: {{.Version}}
 source:
 {{- with .Source }}
   name: {{.Name}}
+  {{- if .Scope}}
   scope: {{.Scope}}
+  {{- end}}
   config: {{.SampleConfig | rawfmt | indent 4}}
 {{- end }}
 {{- if ne (len .Sinks) 0 }}

--- a/plugins/base_extractor.go
+++ b/plugins/base_extractor.go
@@ -3,6 +3,7 @@ package plugins
 import "context"
 
 type BaseExtractor struct {
+	ScopeNotRequired bool
 	BasePlugin
 }
 
@@ -14,7 +15,7 @@ func NewBaseExtractor(info Info, configRef interface{}) BaseExtractor {
 
 // Validate checks if the given options is valid for the plugin.
 func (p *BaseExtractor) Validate(config Config) error {
-	if config.URNScope == "" {
+	if config.URNScope == "" && !p.ScopeNotRequired {
 		return ErrEmptyURNScope
 	}
 

--- a/plugins/extractors/bigquery/bigquery.go
+++ b/plugins/extractors/bigquery/bigquery.go
@@ -83,6 +83,7 @@ func New(logger log.Logger) *Extractor {
 		galClient: galc,
 	}
 	e.BaseExtractor = plugins.NewBaseExtractor(info, &e.config)
+	e.ScopeNotRequired = true
 
 	return e
 }

--- a/plugins/extractors/bigtable/bigtable.go
+++ b/plugins/extractors/bigtable/bigtable.go
@@ -61,6 +61,7 @@ func New(logger log.Logger) *Extractor {
 		logger: logger,
 	}
 	e.BaseExtractor = plugins.NewBaseExtractor(info, &e.config)
+	e.ScopeNotRequired = true
 
 	return e
 }

--- a/plugins/extractors/gcs/gcs.go
+++ b/plugins/extractors/gcs/gcs.go
@@ -68,6 +68,7 @@ func New(logger log.Logger) *Extractor {
 		logger: logger,
 	}
 	e.BaseExtractor = plugins.NewBaseExtractor(info, &e.config)
+	e.ScopeNotRequired = true
 
 	return e
 }

--- a/plugins/extractors/redshift/redshift.go
+++ b/plugins/extractors/redshift/redshift.go
@@ -69,6 +69,8 @@ func New(logger log.Logger, opts ...Option) *Extractor {
 		logger: logger,
 	}
 	e.BaseExtractor = plugins.NewBaseExtractor(info, &e.config)
+	e.ScopeNotRequired = true
+
 	for _, opt := range opts {
 		opt(e)
 	}


### PR DESCRIPTION
User-specified scope is not used in some extractors for generating the URN. Skip validation on the 'scope' being present for such cases:
- bigquery
- bigtable
- gcs
- redshift