### PR TITLE
fix: include project in URN for caramlstore extractor

### DIFF
--- a/plugins/extractors/caramlstore/asset_builder.go
+++ b/plugins/extractors/caramlstore/asset_builder.go
@@ -55,7 +55,7 @@ func (b featureTableBuilder) buildAsset(ft *core.FeatureTable) (*v1beta2.Asset, 
 	}
 
 	return &v1beta2.Asset{
-		Urn:     models.NewURN(service, b.scope, typ, ft.Spec.Name),
+		Urn:     models.NewURN(service, b.scope, typ, b.project+"-"+ft.Spec.Name),
 		Name:    ft.Spec.Name,
 		Service: service,
 		Type:    typ,

--- a/plugins/extractors/caramlstore/testdata/expected-assets.json
+++ b/plugins/extractors/caramlstore/testdata/expected-assets.json
@@ -1,6 +1,6 @@
 [
   {
-    "urn": "urn:caramlstore:test-caramlstore:feature_table:merchant_uuid_t2_discovery",
+    "urn": "urn:caramlstore:test-caramlstore:feature_table:sauron-merchant_uuid_t2_discovery",
     "name": "merchant_uuid_t2_discovery",
     "service": "caramlstore",
     "type": "feature_table",
@@ -88,7 +88,7 @@
     }
   },
   {
-    "urn": "urn:caramlstore:test-caramlstore:feature_table:avg_dispatch_arrival_time_10_mins",
+    "urn": "urn:caramlstore:test-caramlstore:feature_table:sauron-avg_dispatch_arrival_time_10_mins",
     "name": "avg_dispatch_arrival_time_10_mins",
     "service": "caramlstore",
     "type": "feature_table",
@@ -136,7 +136,7 @@
     }
   },
   {
-    "urn": "urn:caramlstore:test-caramlstore:feature_table:merchant_uuid_t2_discovery",
+    "urn": "urn:caramlstore:test-caramlstore:feature_table:food-tensoba-merchant_uuid_t2_discovery",
     "name": "merchant_uuid_t2_discovery",
     "service": "caramlstore",
     "type": "feature_table",
@@ -224,7 +224,7 @@
     }
   },
   {
-    "urn": "urn:caramlstore:test-caramlstore:feature_table:avg_dispatch_arrival_time_10_mins",
+    "urn": "urn:caramlstore:test-caramlstore:feature_table:food-tensoba-avg_dispatch_arrival_time_10_mins",
     "name": "avg_dispatch_arrival_time_10_mins",
     "service": "caramlstore",
     "type": "feature_table",


### PR DESCRIPTION
Since feature table names are not guarenteed to be unique across projects, including the project name in the URN ensures that they do not conflict.