### PR TITLE
fix: carry forward changes by prev processor for next

### DIFF
--- a/agent/stream.go
+++ b/agent/stream.go
@@ -130,14 +130,15 @@ func (s *stream) Close() {
 	}
 }
 
-func (s *stream) runMiddlewares(d models.Record) (res models.Record, err error) {
-	res = d
+func (s *stream) runMiddlewares(d models.Record) (models.Record, error) {
+	res := d
 	for _, middleware := range s.middlewares {
-		res, err = middleware(d)
+		var err error
+		res, err = middleware(res)
 		if err != nil {
-			return
+			return models.Record{}, err
 		}
 	}
 
-	return
+	return res, nil
 }


### PR DESCRIPTION
With multiple processors, the changes by the a given processor would be lost when the next processor was run. Use the result from running the processor while calling the next one.

Closes #444 