### PR TITLE
fix: avoid race conditions from concurrent modification of data

### DIFF
--- a/plugins/extractors/merlin/merlin.go
+++ b/plugins/extractors/merlin/merlin.go
@@ -176,7 +176,7 @@ func (e *Extractor) startWorkers(
 func (e *Extractor) extractProject(ctx context.Context, prj merlin.Project, emit plugins.Emit) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			e.logger.Error("panic recovered")
+			e.logger.Error("panic recovered", "err", r)
 			e.logger.Info(string(debug.Stack()))
 			if e, ok := r.(error); ok {
 				err = fmt.Errorf("extract project '%d': panic: %w", prj.ID, e)


### PR DESCRIPTION
- Use atomic int for incrementing record count in agent run.
- Protect fields that can be concurrently modified in a stream instance using a mutex.
- Don't modify slice to collect runs concurrently while running multiple recipes in agent. Use channels to collect runs instead.
- Avoid referring to and modification of errors or values declared outside closures.