### PR TITLE
feat!: extend HTTP extractor

### DIFF
--- a/plugins/internal/tengoutil/secure_script.go
+++ b/plugins/internal/tengoutil/secure_script.go
@@ -1,6 +1,8 @@
 package tengoutil
 
 import (
+	"fmt"
+
 	"github.com/d5/tengo/v2"
 	"github.com/d5/tengo/v2/stdlib"
 )
@@ -10,15 +12,21 @@ const (
 	maxConsts = 500
 )
 
-func NewSecureScript(input []byte) *tengo.Script {
+func NewSecureScript(input []byte, globals map[string]interface{}) (*tengo.Script, error) {
 	s := tengo.NewScript(input)
 
 	s.SetImports(stdlib.GetModuleMap(
-		// `os` is excluded, should not be importable from script.
+		// `os` is excluded, should *not* be importable from script.
 		"math", "text", "times", "rand", "fmt", "json", "base64", "hex", "enum",
 	))
 	s.SetMaxAllocs(maxAllocs)
 	s.SetMaxConstObjects(maxConsts)
 
-	return s
+	for name, v := range globals {
+		if err := s.Add(name, v); err != nil {
+			return nil, fmt.Errorf("new secure script: declare globals: %w", err)
+		}
+	}
+
+	return s, nil
 }

--- a/plugins/internal/tengoutil/secure_script_test.go
+++ b/plugins/internal/tengoutil/secure_script_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewSecureScript(t *testing.T) {
 	t.Run("Allows import of builtin modules except os", func(t *testing.T) {
-		s := NewSecureScript(([]byte)(heredoc.Doc(`
+		s, err := NewSecureScript(([]byte)(heredoc.Doc(`
 			math := import("math")
 			text := import("text")
 			times := import("times")
@@ -22,20 +22,37 @@ func TestNewSecureScript(t *testing.T) {
 			base64 := import("base64")
 			hex := import("hex")
 			enum := import("enum")
-		`)))
-		_, err := s.Compile()
+		`)), nil)
+		assert.NoError(t, err)
+		_, err = s.Compile()
 		assert.NoError(t, err)
 	})
 
 	t.Run("os import disallowed", func(t *testing.T) {
-		s := NewSecureScript(([]byte)(`os := import("os")`))
-		_, err := s.Compile()
+		s, err := NewSecureScript(([]byte)(`os := import("os")`), nil)
+		assert.NoError(t, err)
+		_, err = s.Compile()
 		assert.ErrorContains(t, err, "Compile Error: module 'os' not found")
 	})
 
 	t.Run("File import disallowed", func(t *testing.T) {
-		s := NewSecureScript(([]byte)(`sum := import("./testdata/sum")`))
-		_, err := s.Compile()
+		s, err := NewSecureScript(([]byte)(`sum := import("./testdata/sum")`), nil)
+		assert.NoError(t, err)
+		_, err = s.Compile()
 		assert.ErrorContains(t, err, "Compile Error: module './testdata/sum' not found")
+	})
+
+	t.Run("Script globals", func(t *testing.T) {
+		s, err := NewSecureScript(([]byte)(`obj.prop = 1`), nil)
+		assert.NoError(t, err)
+		_, err = s.Compile()
+		assert.ErrorContains(t, err, "Compile Error: unresolved reference 'obj'")
+
+		s, err = NewSecureScript(([]byte)(`obj.prop = 1`), map[string]interface{}{
+			"obj": map[string]interface{}{},
+		})
+		assert.NoError(t, err)
+		_, err = s.Compile()
+		assert.NoError(t, err)
 	})
 }

--- a/plugins/internal/tengoutil/structmap/structmap.go
+++ b/plugins/internal/tengoutil/structmap/structmap.go
@@ -42,12 +42,17 @@ func AsMap(v interface{}) (interface{}, error) {
 }
 
 func AsStruct(input, output interface{}) error {
+	return AsStructWithTag("json", input, output)
+}
+
+func AsStructWithTag(tagName string, input, output interface{}) error {
 	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			checkAssetDataHookFunc(),
 			stringToTimestampHookFunc(time.RFC3339),
 			timeToTimestampHookFunc(),
 			mapstructure.StringToTimeHookFunc(time.RFC3339),
+			mapstructure.StringToTimeDurationHookFunc(),
 			mapToAttributesHookFunc(),
 			mapToAnyPBHookFunc(),
 		),
@@ -55,7 +60,7 @@ func AsStruct(input, output interface{}) error {
 		ErrorUnused:      true,
 		ZeroFields:       true,
 		Result:           output,
-		TagName:          "json",
+		TagName:          tagName,
 	})
 	if err != nil {
 		return fmt.Errorf("structmap: decode into %T: create decoder: %w", output, err)

--- a/plugins/internal/tengoutil/structmap/structmap_test.go
+++ b/plugins/internal/tengoutil/structmap/structmap_test.go
@@ -181,6 +181,17 @@ func TestAsMap(t *testing.T) {
 	}
 }
 
+func TestAsStructWithTag(t *testing.T) {
+	type V struct {
+		Duration time.Duration `myspltag:"duration"`
+	}
+	input := map[string]interface{}{"duration": "5s"}
+	var v V
+	err := AsStructWithTag("myspltag", input, &v)
+	assert.NoError(t, err)
+	assert.Equal(t, V{Duration: time.Second * 5}, v)
+}
+
 func TestAsStruct(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -383,7 +394,7 @@ func TestAsStruct(t *testing.T) {
 				"type":           "table",
 				"data":           map[string]interface{}{},
 			},
-			expected: &v1beta2.Asset{},
+			expected:    &v1beta2.Asset{},
 			expectedErr: "invalid keys: does-not-exist",
 		},
 		{

--- a/plugins/processors/script/tengo_script.go
+++ b/plugins/processors/script/tengo_script.go
@@ -70,8 +70,10 @@ func (p *Processor) Init(ctx context.Context, config plugins.Config) error {
 		return fmt.Errorf("script processor init: %w", err)
 	}
 
-	s := tengoutil.NewSecureScript(([]byte)(p.config.Script))
-	if err := p.declareGlobals(s); err != nil {
+	s, err := tengoutil.NewSecureScript(([]byte)(p.config.Script), map[string]interface{}{
+		"asset": map[string]interface{}{},
+	})
+	if err != nil {
 		return fmt.Errorf("script processor init: %w", err)
 	}
 
@@ -107,15 +109,4 @@ func (p *Processor) Process(ctx context.Context, src models.Record) (models.Reco
 	}
 
 	return models.NewRecord(transformed), nil
-}
-
-func (p *Processor) declareGlobals(s *tengo.Script) error {
-	for name, v := range map[string]interface{}{
-		"asset": map[string]interface{}{},
-	} {
-		if err := s.Add(name, v); err != nil {
-			return fmt.Errorf("declare script globals: %w", err)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
- Add script global function `execute_request` for being able to execute 1 or more HTTP requests using the request configuration options similar to recipe config.
- Instead of only providing the response body to the script, provide the {status_code, header, body}.
- Allow configuration of concurrency to control the number of concurrent HTTP requests made from inside the script.

BREAKING CHANGE: The response provided to the script in HTTP extractor has the {status_code, header, body} instead of just the response body.