### PR TITLE
fix: extract io writer in recipe generator

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"os"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -89,13 +90,13 @@ func NewRecipeCmd() *cobra.Command {
 				}
 			}
 
-			return generator.Recipe(generator.RecipeParams{
+			return generator.RecipeWriteTo(generator.RecipeParams{
 				Name:       args[0],
 				Source:     extractor,
 				Scope:      scope,
 				Sinks:      sinkList,
 				Processors: procList,
-			})
+			}, os.Stdout)
 		},
 	}
 


### PR DESCRIPTION
Meteor `new` command allows user to generate recipe, although the functionality is fine, I want use this method to generate recipe outside of meteor as well. If this is being called programmatically printing it to hard coded stdout blocked me to take the output as a string.