### PR TITLE
feat(extractor-plugins): add crawler specifications

### DIFF
--- a/plugins/extractors/cassandra/README.md
+++ b/plugins/extractors/cassandra/README.md
@@ -10,34 +10,39 @@ source:
     password: 1234
     host: localhost
     port: 9042
+    exclude:
+      keyspaces: [mykeyspace]
+      tables: [mykeyspace_2.tableName_1]
 ```
 
 ## Inputs
 
-| Key | Value | Example | Description |    |
-| :-- | :---- | :------ | :---------- | :- |
-| `user_id` | `string` | `admin` | User ID to access the cassandra server| *required* |
-| `password` | `string` | `1234` | Password for the cassandra Server | *required* |
-| `host` | `string` | `127.0.0.1` | The Host address at which server is running | *required* |
-| `port` | `int` | `9042` | The Port number at which server is running | *required* |
+| Key                 | Value      | Example                 | Description                                    |            |
+| :------------------ | :--------- | :---------------------- | :--------------------------------------------- | :--------- |
+| `user_id`           | `string`   | `admin`                 | User ID to access the cassandra server         | _required_ |
+| `password`          | `string`   | `1234`                  | Password for the cassandra Server              | _required_ |
+| `host`              | `string`   | `127.0.0.1`             | The Host address at which server is running    | _required_ |
+| `port`              | `int`      | `9042`                  | The Port number at which server is running     | _required_ |
+| `exclude.keyspcaes` | `[]string` | `[keyspace1,keyspace2]` | List of keyspaces to be excluded from crawling | _optional_ |
+| `exclude.tables`    | `[]string` | `[keyspace3.table1]`    | List of tables to be excluded from crawling    | _optional_ |
 
 ## Outputs
 
-| Field | Sample Value |
-| :---- | :---- |
-| `resource.urn` | `my_keyspace.my_table` |
-| `resource.name` | `my_table` |
-| `resource.service` | `cassandra` |
-| `description` | `table description` |
-| `profile.total_rows` | `2100` |
-| `schema` | [][Column](#column) |
+| Field                | Sample Value           |
+| :------------------- | :--------------------- |
+| `resource.urn`       | `my_keyspace.my_table` |
+| `resource.name`      | `my_table`             |
+| `resource.service`   | `cassandra`            |
+| `description`        | `table description`    |
+| `profile.total_rows` | `2100`                 |
+| `schema`             | [][column](#column)    |
 
 ### Column
 
-| Field | Sample Value |
-| :---- | :---- |
+| Field  | Sample Value  |
+| :----- | :------------ |
 | `name` | `total_price` |
-| `type` | `text` |
+| `type` | `text`        |
 
 ## Contributing
 

--- a/plugins/extractors/clickhouse/README.md
+++ b/plugins/extractors/clickhouse/README.md
@@ -6,33 +6,38 @@
 source:
   name: clickhouse
   config:
-    connection_url: tcp://localhost:3306?username=admin&password=pass123&debug=true
+    connection_url: clickhouse://username:password@clickhouse-server:9000
+    exclude:
+      databases: [database_a, database_b]
+      tables: [database_c.table_a]
 ```
 
 ## Inputs
 
-| Key | Value | Example | Description |    |
-| :-- | :---- | :------ | :---------- | :- |
-| `connection_url` | `string` | `tcp://localhost:3306?username=admin&password=pass123&debug=true` | URL to access the clickhouse server | *required* |
+| Key                 | Value      | Example                                                           | Description                         |            |
+| :------------------ | :--------- | :---------------------------------------------------------------- | :---------------------------------- | :--------- |
+| `connection_url`    | `string`   | `tcp://localhost:3306?username=admin&password=pass123&debug=true` | URL to access the clickhouse server | _required_ |
+| `exclude.databases` | `[]string` | `[database_a`, `database_b]`                                      | List of databases to be excluded    | _optional_ |
+| `exclude.tables`    | `[]string` | `[database_c.table_a, database_c.table_b]`                        | List of tables to be excluded       | _optional_ |
 
 ## Outputs
 
-| Field | Sample Value |
-| :---- | :---- |
-| `resource.urn` | `my_database.my_table` |
-| `resource.name` | `my_table` |
-| `resource.service` | `clickhouse` |
-| `description` | `table description` |
-| `profile.total_rows` | `2100` |
-| `schema` | [][Column](#column) |
+| Field                | Sample Value           |
+| :------------------- | :--------------------- |
+| `resource.urn`       | `my_database.my_table` |
+| `resource.name`      | `my_table`             |
+| `resource.service`   | `clickhouse`           |
+| `description`        | `table description`    |
+| `profile.total_rows` | `2100`                 |
+| `schema`             | [][column](#column)    |
 
 ### Column
 
-| Field | Sample Value |
-| :---- | :---- |
-| `name` | `total_price` |
+| Field         | Sample Value         |
+| :------------ | :------------------- |
+| `name`        | `total_price`        |
 | `description` | `item's total price` |
-| `data_type` | `String` |
+| `data_type`   | `String`             |
 
 ## Contributing
 

--- a/plugins/extractors/couchdb/README.md
+++ b/plugins/extractors/couchdb/README.md
@@ -7,31 +7,33 @@ source:
   name: couchdb
   config:
     connection_url: http://admin:pass123@localhost:3306/
+    exclude: database_a,database_b
 ```
 
 ## Inputs
 
-| Key | Value | Example | Description |    |
-| :-- | :---- | :------ | :---------- | :- |
-| `connection_url` | `string` | `http://admin:pass123@localhost:3306/` | URL to access the couchdb server | *required* |
+| Key              | Value    | Example                                | Description                                                |            |
+| :--------------- | :------- | :------------------------------------- | :--------------------------------------------------------- | :--------- |
+| `connection_url` | `string` | `http://admin:pass123@localhost:3306/` | URL to access the couchdb server                           | _required_ |
+| `exclude`        | `string` | `primaryDB,secondaryDB`                | Comma separated database list to be excluded from crawling | _optional_ |
 
 ## Outputs
 
-| Field | Sample Value |
-| :---- | :---- |
-| `resource.urn` | `database_name.docID` |
-| `resource.name` | `docID` |
-| `resource.service` | `couchdb` |
-| `schema` | [][Column](#column) |
+| Field              | Sample Value          |
+| :----------------- | :-------------------- |
+| `resource.urn`     | `database_name.docID` |
+| `resource.name`    | `docID`               |
+| `resource.service` | `couchdb`             |
+| `schema`           | [][column](#column)   |
 
 ### Column
 
-| Field | Sample Value |
-| :---- | :---- |
-| `name` | `field1` |
+| Field         | Sample Value               |
+| :------------ | :------------------------- |
+| `name`        | `field1`                   |
 | `description` | `rev for revision history` |
-| `data_type` | `float64` |
-| `length` | `` |
+| `data_type`   | `float64`                  |
+| `length`      | ``                         |
 
 ## Contributing
 

--- a/plugins/extractors/gcs/README.md
+++ b/plugins/extractors/gcs/README.md
@@ -4,7 +4,7 @@
 
 ```yaml
 source:
-  name: googlecloudstorage
+  name: gcs
   config:
     project_id: google-project-id
     extract_blob: true
@@ -18,50 +18,52 @@ source:
         "auth_uri": "https://accounts.google.com/o/oauth2/auth",
         "token_uri": "https://oauth2.googleapis.com/token",
         "auth_provider_x509_cert_url": "xxxxxxx",
-        "client_x509_cert_url": "xxxxxxx"
+        "client_x509_cert_url": "xxxxxxx",
       }
+    exclude: [bucket_a, bucket_b]
 ```
 
 ## Inputs
 
-| Key | Value | Example | Description |    |
-| :-- | :---- | :------ | :---------- | :- |
-| `project_id` | `string` | `my-project` | BigQuery Project ID | *required* |
-| `extract_blob` | `boolean` | `true` | Extract blob metadata inside a bucket | *optional* |
-| `credentials_json` | `string` | `{"private_key": .., "private_id": ...}` | Service Account in JSON string | *optional* |
+| Key                | Value      | Example                                  | Description                                     |            |
+| :----------------- | :--------- | :--------------------------------------- | :---------------------------------------------- | :--------- |
+| `project_id`       | `string`   | `my-project`                             | Cloud Storage Project ID                             | _required_ |
+| `extract_blob`     | `boolean`  | `true`                                   | Extract blob metadata inside a bucket           | _optional_ |
+| `credentials_json` | `string`   | `{"private_key": .., "private_id": ...}` | Service Account in JSON string                  | _optional_ |
+| `exclude`          | `[]string` | `["bucket_a","bucket_b"]`                | Array of bucket names to excluded from crawling | _optional_ |
 
-### *Notes*
+### _Notes_
 
 Leaving `credentials_json` blank will default to [Google's default authentication](https://cloud.google.com/docs/authentication/production#automatically). It is recommended if Meteor instance runs inside the same Google Cloud environment as the Google Cloud Storage project.
 
 ## Outputs
 
-| Field | Sample Value |
-| :---- | :---- |
-| `resource.urn` | `project_id/bucket_name` |
-| `resource.name` | `bucket_name` |
-| `resource.service` | `googlecloudstorage` |
-| `location` | `ASIA` |
-| `storage_type` | `STANDARD` |
-| `labels` | []{`key`:`value`} |
-| `timestamps.created_at.seconds` | `1551082913` |
-| `timestamps.created_at.nanos` | `1551082913` |
+| Field                           | Sample Value             |
+| :------------------------------ | :----------------------- |
+| `resource.urn`                  | `project_id/bucket_name` |
+| `resource.name`                 | `bucket_name`            |
+| `resource.service`              | `gcs`                    |
+| `location`                      | `ASIA`                   |
+| `storage_type`                  | `STANDARD`               |
+| `labels`                        | []{`key`:`value`}        |
+| `timestamps.created_at.seconds` | `1551082913`             |
+| `timestamps.created_at.nanos`   | `1551082913`             |
 
 ### Blob
 
-| Field | Sample Value |
-| :---- | :---- |
-| `urn` | `project_id/bucket_name/blob_path` |
-| `name` | `blob_path` |
-| `size` | `311` |
-| `deleted_at.seconds` | `1551082913` |
-| `expired_at.seconds` | `1551082913` |
-| `labels` | []{`key`:`value`} |
-| `ownership.owners` | []{`name`:`serviceaccountname@project.gserviceaccount.com`} |
-| `timestamps.created_at.seconds` | `1551082913` |
-| `timestamps.created_at.nanos` | `1551082913` |
-| `timestamps.updated_at.seconds` | `1551082913` |
-| `timestamps.updated_at.nanos` | `1551082913` |
+| Field                           | Sample Value                                                |
+| :------------------------------ | :---------------------------------------------------------- |
+| `urn`                           | `project_id/bucket_name/blob_path`                          |
+| `name`                          | `blob_path`                                                 |
+| `size`                          | `311`                                                       |
+| `deleted_at.seconds`            | `1551082913`                                                |
+| `expired_at.seconds`            | `1551082913`                                                |
+| `labels`                        | []{`key`:`value`}                                           |
+| `ownership.owners`              | []{`name`:`serviceaccountname@project.gserviceaccount.com`} |
+| `timestamps.created_at.seconds` | `1551082913`                                                |
+| `timestamps.created_at.nanos`   | `1551082913`                                                |
+| `timestamps.updated_at.seconds` | `1551082913`                                                |
+| `timestamps.updated_at.nanos`   | `1551082913`                                                |
 
 ## Contributing
 

--- a/plugins/extractors/grafana/README.md
+++ b/plugins/extractors/grafana/README.md
@@ -8,39 +8,47 @@ source:
   config:
     base_url: grafana_server
     api_key: your_api_key
+    exclude:
+      dashboards:
+        - dashboard_ud_1
+        - dashboard_ud_2
+      panels:
+        - dashboard_uid_3.panel_id_1
 ```
 
 ## Inputs
 
-| Key | Value | Example | Description |    |
-| :-- | :---- | :------ | :---------- | :- |
-| `base_url` | `string` | `http://localhost:3000` | URL of the Grafana server | *required* |
-| `api_key` | `string` | `Bearer qweruqwryqwLKJ` | API key to access Grafana API | *required* |
+| Key                  | Value      | Example                            | Description                                    |            |
+| :------------------- | :--------- | :--------------------------------- | :--------------------------------------------- | :--------- |
+| `base_url`           | `string`   | `http://localhost:3000`            | URL of the Grafana server                      | _required_ |
+| `api_key`            | `string`   | `Bearer qweruqwryqwLKJ`            | API key to access Grafana API                  | _required_ |
+| `exclude.dashboards` | `[]string` | `[dashboard_ud_1, dashboard_ud_2]` | List of dasboards to be excluded from crawling | _optional_ |
+| `exclude.panels`     | `[]string` | `[dashboard_uid_3.panel_id_1]`     | List of panels to be excluded from crawling    | _optional_ |
 
 ## Outputs
 
-| Field | Sample Value |
-| :---- | :---- |
-| `resource.urn` | `grafana.HzK8qNW7z` |
-| `resource.name` | `new-dashboard-copy` |
-| `resource.service` | `grafana` |
-| `resource.url` | `http://localhost:3000/d/HzK8qNW7z/new-dashboard-copy` |
-| `charts` | [][chart](#chart) |
+| Field              | Sample Value                                           |
+| :----------------- | :----------------------------------------------------- |
+| `resource.urn`     | `grafana.HzK8qNW7z`                                    |
+| `resource.name`    | `new-dashboard-copy`                                   |
+| `resource.service` | `grafana`                                              |
+| `resource.url`     | `http://localhost:3000/d/HzK8qNW7z/new-dashboard-copy` |
+| `charts`           | [][chart](#chart)                                      |
 
 ### Chart
 
-| Field | Sample Value |
-| :---- | :---- |
-| `urn` | `5WsKOvW7z.4` |
-| `name` | `Panel Random` |
-| `type` | `table` |
-| `source` | `grafana` |
-| `description` | `random description for this panel` |
-| `url` | `http://localhost:3000/d/5WsKOvW7z/test-dashboard-updated?viewPanel=4` |
-| `data_source` | `postgres` |
-| `raw_query` | `SELECT\n  urn,\n  created_at AS \"time\"\nFROM resources\nORDER BY 1` |
-| `dashboard_urn` | `grafana.5WsKOvW7z` |
-| `dashboard_source` | `grafana` |
+| Field              | Sample Value                                                           |
+| :----------------- | :--------------------------------------------------------------------- |
+| `urn`              | `5WsKOvW7z.4`                                                          |
+| `name`             | `Panel Random`                                                         |
+| `type`             | `table`                                                                |
+| `source`           | `grafana`                                                              |
+| `description`      | `random description for this panel`                                    |
+| `url`              | `http://localhost:3000/d/5WsKOvW7z/test-dashboard-updated?viewPanel=4` |
+| `data_source`      | `postgres`                                                             |
+| `raw_query`        | `SELECT\n  urn,\n  created_at AS \"time\"\nFROM resources\nORDER BY 1` |
+| `dashboard_urn`    | `grafana.5WsKOvW7z`                                                    |
+| `dashboard_source` | `grafana`                                                              |
 
 ## Contributing
 

--- a/plugins/extractors/mariadb/README.md
+++ b/plugins/extractors/mariadb/README.md
@@ -7,34 +7,42 @@ source:
   type: mariadb
   config:
     connection_url: admin:pass123@tcp(localhost:3306)/
+    exclude:
+      databases:
+        - database_a
+        - database_b
+      tables:
+        - database_c.table_a
 ```
 
 ## Inputs
 
-| Key | Value | Example | Description |    |
-| :-- | :---- | :------ | :---------- | :- |
-| `connection_url` | `string` | `admin:pass123@tcp(localhost:3306)/` | URL to access the mariadb server | *required* |
+| Key                 | Value      | Example                                        | Description                      |            |
+| :------------------ | :--------- | :--------------------------------------------- | :------------------------------- | :--------- |
+| `connection_url`    | `string`   | `admin:pass123@tcp(localhost:3306)/`           | URL to access the mariadb server | _required_ |
+| `exclude.databases` | `[]string` | `[`database_a`, `database_b`]`                 | List of databases to be excluded | _optional_ |
+| `exclude.tables`    | `[]string` | `[`database_c.table_a`, `database_c.table_b`]` | List of tables to be excluded    | _optional_ |
 
 ## Outputs
 
-| Field | Sample Value |
-| :---- | :---- |
-| `resource.urn` | `my_database.my_table` |
-| `resource.name` | `my_table` |
-| `resource.service` | `mariadb` |
-| `description` | `table description` |
-| `profile.total_rows` | `1100` |
-| `schema` | [][Column](#column) |
+| Field                | Sample Value           |
+| :------------------- | :--------------------- |
+| `resource.urn`       | `my_database.my_table` |
+| `resource.name`      | `my_table`             |
+| `resource.service`   | `mariadb`              |
+| `description`        | `table description`    |
+| `profile.total_rows` | `1100`                 |
+| `schema`             | [][column](#column)    |
 
 ### Column
 
-| Field | Sample Value |
-| :---- | :---- |
-| `name` | `total_price` |
+| Field         | Sample Value         |
+| :------------ | :------------------- |
+| `name`        | `total_price`        |
 | `description` | `item's total price` |
-| `data_type` | `decimal` |
-| `is_nullable` | `true` |
-| `length` | `11` |
+| `data_type`   | `decimal`            |
+| `is_nullable` | `true`               |
+| `length`      | `11`                 |
 
 ## Contributing
 

--- a/plugins/extractors/mongodb/README.md
+++ b/plugins/extractors/mongodb/README.md
@@ -7,6 +7,12 @@ source:
   name: mongodb
   config:
     connection_url: mongodb://admin:pass123@localhost:3306
+    exclude:
+      databases:
+        - database_a
+        - database_b
+      collections:
+        - database_c.collection_a
 ```
 
 ## Inputs
@@ -14,6 +20,8 @@ source:
 | Key | Value | Example | Description |    |
 | :-- | :---- | :------ | :---------- | :- |
 | `connection_url` | `string` | `mongodb://admin:pass123@localhost:3306` | URL to access the mongodb server | *required* |
+| `exclude.databases` | `[]string` | `[`database_a`, `database_b`]` | List of databases to be excluded | *optional* |
+| `exclude.collections` | `[]string` | `[`database_c.collection_a`, `database_c.collection_b`]` | List of collections to be excluded | *optional* |
 
 ## Outputs
 

--- a/plugins/extractors/mongodb/mongodb.go
+++ b/plugins/extractors/mongodb/mongodb.go
@@ -31,10 +31,23 @@ var defaultCollections = []string{
 
 // Config holds the connection URL for the extractor
 type Config struct {
-	ConnectionURL string `json:"connection_url" yaml:"connection_url" mapstructure:"connection_url" validate:"required"`
+	ConnectionURL string  `json:"connection_url" yaml:"connection_url" mapstructure:"connection_url" validate:"required"`
+	Exclude       Exclude `json:"exclude" yaml:"exclude" mapstructure:"exclude"`
 }
 
-var sampleConfig = `connection_url: "mongodb://admin:pass123@localhost:3306"`
+type Exclude struct {
+	Databases   []string `json:"databases" yaml:"databases" mapstructure:"databases"`
+	Collections []string `json:"collections" yaml:"collections" mapstructure:"collections"`
+}
+
+var sampleConfig = `
+connection_url: "mongodb://admin:pass123@localhost:3306"
+exclude:
+  databases:
+	- database_a
+	- database_b
+  collections:
+	- dataset_c.table_a`
 
 var info = plugins.Info{
 	Description:  "Collection metadata from MongoDB Server",
@@ -47,10 +60,9 @@ var info = plugins.Info{
 type Extractor struct {
 	plugins.BaseExtractor
 	// internal states
-	client   *mongo.Client
-	excluded map[string]bool
-	logger   log.Logger
-	config   Config
+	client *mongo.Client
+	logger log.Logger
+	config Config
 }
 
 // New returns a pointer to an initialized Extractor Object
@@ -68,9 +80,6 @@ func (e *Extractor) Init(ctx context.Context, config plugins.Config) (err error)
 		return err
 	}
 
-	// build excluded list
-	e.buildExcludedCollections()
-
 	// setup client
 	if e.client, err = createAndConnnectClient(ctx, e.config.ConnectionURL); err != nil {
 		return errors.Wrap(err, "failed to create client")
@@ -87,6 +96,10 @@ func (e *Extractor) Extract(ctx context.Context, emit plugins.Emit) (err error) 
 	}
 
 	for _, dbName := range databases {
+		if e.isExcludedDB(dbName, e.config.Exclude.Databases) {
+			continue
+		}
+
 		database := e.client.Database(dbName)
 		if err := e.extractCollections(ctx, database, emit); err != nil {
 			return errors.Wrap(err, "failed to extract collections")
@@ -108,8 +121,8 @@ func (e *Extractor) extractCollections(ctx context.Context, db *mongo.Database, 
 	// or else test might fail
 	sort.Strings(collections)
 	for _, collectionName := range collections {
-		// skip if collection is default mongo
-		if e.isDefaultCollection(collectionName) {
+		// skip if collection is default mongo or is in the user's exclude collection list
+		if e.isExcludedCollection(collectionName, db.Name(), e.config.Exclude.Collections) {
 			continue
 		}
 
@@ -152,20 +165,29 @@ func (e *Extractor) buildTable(ctx context.Context, db *mongo.Database, collecti
 	return
 }
 
-// Build a map of excluded collections using list of collection names
-func (e *Extractor) buildExcludedCollections() {
-	excluded := make(map[string]bool)
-	for _, collection := range defaultCollections {
-		excluded[collection] = true
+// Check if collection is default or in user's exclude list
+func (e *Extractor) isExcludedCollection(collName string, dbName string, excludedCollections []string) bool {
+	collectionName := fmt.Sprintf("%s.%s", dbName, collName)
+	excludedCollections = append(excludedCollections, defaultCollections...)
+
+	for _, c := range excludedCollections {
+		if c == collectionName {
+			return true
+		}
 	}
 
-	e.excluded = excluded
+	return false
 }
 
-// Check if collection is default using stored map
-func (e *Extractor) isDefaultCollection(collectionName string) bool {
-	_, ok := e.excluded[collectionName]
-	return ok
+// isExcludedDB checks if the given db is in the list of excluded databases
+func (e *Extractor) isExcludedDB(dbName string, excludeDatabases []string) bool {
+	for _, d := range excludeDatabases {
+		if d == dbName {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Create mongo client and tries to connect

--- a/plugins/extractors/mongodb/mongodb.go
+++ b/plugins/extractors/mongodb/mongodb.go
@@ -168,10 +168,16 @@ func (e *Extractor) buildTable(ctx context.Context, db *mongo.Database, collecti
 // Check if collection is default or in user's exclude list
 func (e *Extractor) isExcludedCollection(collName string, dbName string, excludedCollections []string) bool {
 	collectionName := fmt.Sprintf("%s.%s", dbName, collName)
-	excludedCollections = append(excludedCollections, defaultCollections...)
 
+	// check if collection is in the user's exclude list (dbName.CollectionName)
 	for _, c := range excludedCollections {
 		if c == collectionName {
+			return true
+		}
+	}
+	// check if collection is default mongo collection (like *.system.version, *.system.users)
+	for _, c := range defaultCollections {
+		if c == collName {
 			return true
 		}
 	}

--- a/plugins/extractors/mssql/README.md
+++ b/plugins/extractors/mssql/README.md
@@ -7,34 +7,42 @@ source:
   name: mssql
   config:
     connection_url: sqlserver://admin:pass123@localhost:3306/
+    exclude:
+      databases:
+        - database_a
+        - database_b
+      tables:
+        - database_c.table_a
 ```
 
 ## Inputs
 
-| Key | Value | Example | Description |    |
-| :-- | :---- | :------ | :---------- | :- |
-| `identifier` | `string` | `my-mssql` | Instance alias, the value will be used as part of the urn component | *required* |
+| Key                 | Value      | Example                                        | Description                      |            |
+| :------------------ | :--------- | :--------------------------------------------- | :------------------------------- | :--------- |
+| `connection_url`    | `string`   | `sqlserver://admin:pass123@localhost:3306/`    | URL to access the mssql server   | _required_ |
+| `exclude.databases` | `[]string` | `[`database_a`, `database_b`]`                 | List of databases to be excluded | _optional_ |
+| `exclude.tables`    | `[]string` | `[`database_c.table_a`, `database_c.table_b`]` | List of tables to be excluded    | _optional_ |
 
 ## Outputs
 
-| Field | Sample Value |
-| :---- | :---- |
-| `resource.urn` | `mssql::my-mssql/my_database/my_table` |
-| `resource.name` | `my_table` |
-| `resource.service` | `mssql` |
-| `description` | `table description` |
-| `profile.total_rows` | `2100` |
-| `schema` | [][Column](#column) |
+| Field                | Sample Value                           |
+| :------------------- | :------------------------------------- |
+| `resource.urn`       | `mssql::my-mssql/my_database/my_table` |
+| `resource.name`      | `my_table`                             |
+| `resource.service`   | `mssql`                                |
+| `description`        | `table description`                    |
+| `profile.total_rows` | `2100`                                 |
+| `schema`             | [][column](#column)                    |
 
 ### Column
 
-| Field | Sample Value |
-| :---- | :---- |
-| `name` | `total_price` |
+| Field         | Sample Value         |
+| :------------ | :------------------- |
+| `name`        | `total_price`        |
 | `description` | `item's total price` |
-| `data_type` | `decimal` |
-| `is_nullable` | `true` |
-| `length` | `12,2` |
+| `data_type`   | `decimal`            |
+| `is_nullable` | `true`               |
+| `length`      | `12,2`               |
 
 ## Contributing
 

--- a/plugins/extractors/mysql/README.md
+++ b/plugins/extractors/mysql/README.md
@@ -7,6 +7,12 @@ source:
   name: mysql
   config:
     connection_url: admin:pass123@tcp(localhost:3306)/
+    exclude:
+      databases:
+        - database_a
+        - database_b
+      tables:
+        - database_c.table_a
 ```
 
 ## Inputs
@@ -14,7 +20,8 @@ source:
 | Key | Value | Example | Description |    |
 | :-- | :---- | :------ | :---------- | :- |
 | `connection_url` | `string` | `admin:pass123@tcp(localhost:3306)/` | URL to access the mysql server | *required* |
-| `identifier` | `string` | `my-mysql` | Instance alias, the value will be used as part of the urn component | *required* |
+| `exclude.databases` | `[]string` | `[`database_a`, `database_b`]` | List of databases to be excluded | *optional* |
+| `exclude.tables` | `[]string` | `[`database_c.table_a`, `database_c.table_b`]` | List of tables to be excluded | *optional* |
 
 ## Outputs
 

--- a/plugins/extractors/snowflake/README.md
+++ b/plugins/extractors/snowflake/README.md
@@ -7,28 +7,36 @@ source:
   type: snowflake
   config:
     connection_url: user:password@my_organization-my_account/mydb
+    exclude:
+      databases:
+        - database_a
+        - database_b
+      tables:
+        - database_c.table_a
 ```
 
 ## Inputs
 
-| Key | Value | Example | Description |    |
-| :-- | :---- | :------ | :---------- | :- |
-| `connection_url` | `string` | `user:password@org22-acc123/mydb` | URL to access the snowflake server | *required* |
+| Key                 | Value      | Example                                        | Description                        |            |
+| :------------------ | :--------- | :--------------------------------------------- | :--------------------------------- | :--------- |
+| `connection_url`    | `string`   | `user:password@org22-acc123/mydb`              | URL to access the snowflake server | _required_ |
+| `exclude.databases` | `[]string` | `[`database_a`, `database_b`]`                 | List of databases to be excluded   | _optional_ |
+| `exclude.tables`    | `[]string` | `[`database_c.table_a`, `database_c.table_b`]` | List of tables to be excluded      | _optional_ |
 
 ## Outputs
 
 | Field              | Sample Value           |
-|:-------------------|:-----------------------|
+| :----------------- | :--------------------- |
 | `resource.urn`     | `my_database.my_table` |
 | `resource.name`    | `my_table`             |
 | `resource.service` | `snowflake`            |
 | `description`      | `table description`    |
-| `schema`           | [][Column](#column)    |
+| `schema`           | [][column](#column)    |
 
 ### Column
 
 | Field         | Sample Value         |
-|:--------------|:---------------------|
+| :------------ | :------------------- |
 | `name`        | `total_price`        |
 | `description` | `item's total price` |
 | `data_type`   | `decimal`            |

--- a/plugins/extractors/snowflake/snowflake.go
+++ b/plugins/extractors/snowflake/snowflake.go
@@ -153,10 +153,9 @@ func (e *Extractor) extractTables(database string) (err error) {
 	for rows.Next() {
 		var createdOn, name, databaseName, schemaName, kind, comment, clusterBy, owner, autoClustering, changeTracking, isExternal string
 		var bytes, rowsCount, retentionTime int
-		var x, y, z sql.RawBytes
 
 		if err = rows.Scan(&createdOn, &name, &databaseName, &schemaName, &kind, &comment, &clusterBy, &rowsCount,
-			&bytes, &owner, &retentionTime, &autoClustering, &changeTracking, &isExternal, &x, &y, &z); err != nil {
+			&bytes, &owner, &retentionTime, &autoClustering, &changeTracking, &isExternal); err != nil {
 			return err
 		}
 

--- a/plugins/extractors/snowflake/snowflake.go
+++ b/plugins/extractors/snowflake/snowflake.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/odpf/meteor/models"
 	"github.com/odpf/meteor/plugins"
+	"github.com/odpf/meteor/plugins/sqlutil"
 	"github.com/odpf/meteor/registry"
 	"github.com/odpf/salt/log"
 	"github.com/snowflakedb/gosnowflake"
@@ -23,7 +24,13 @@ var summary string
 
 // Config holds the connection URL for the extractor
 type Config struct {
-	ConnectionURL string `json:"connection_url" yaml:"connection_url" mapstructure:"connection_url" validate:"required"`
+	ConnectionURL string  `json:"connection_url" yaml:"connection_url" mapstructure:"connection_url" validate:"required"`
+	Exclude       Exclude `json:"exclude" yaml:"exclude" mapstructure:"exclude"`
+}
+
+type Exclude struct {
+	Databases []string `json:"databases" yaml:"databases" mapstructure:"databases"`
+	Tables    []string `json:"tables" yaml:"tables" mapstructure:"tables"`
 }
 
 var sampleConfig = `connection_url: "user:password@my_organization-my_account/mydb"`
@@ -39,6 +46,8 @@ type Extractor struct {
 	plugins.BaseExtractor
 	logger        log.Logger
 	config        Config
+	excludedDbs   map[string]bool
+	excludedTbl   map[string]bool
 	httpTransport http.RoundTripper
 	db            *sql.DB
 	emit          plugins.Emit
@@ -73,6 +82,10 @@ func (e *Extractor) Init(ctx context.Context, config plugins.Config) (err error)
 	if err = e.BaseExtractor.Init(ctx, config); err != nil {
 		return err
 	}
+
+	// build excluded database list
+	e.excludedDbs = sqlutil.BuildBoolMap(e.config.Exclude.Databases)
+	e.excludedTbl = sqlutil.BuildBoolMap(e.config.Exclude.Tables)
 
 	if e.httpTransport == nil {
 		// create snowflake client
@@ -112,6 +125,10 @@ func (e *Extractor) Extract(_ context.Context, emit plugins.Emit) (err error) {
 		if err = dbs.Scan(&createdOn, &name, &isDefault, &isCurrent, &origin, &owner, &comment, &options, &retentionTime); err != nil {
 			return fmt.Errorf("failed to scan database %s: %w", name, err)
 		}
+		// skip excluded databases
+		if e.excludedDbs[name] {
+			continue
+		}
 		if err = e.extractTables(name); err != nil {
 			return fmt.Errorf("failed to extract tables from %s: %w", name, err)
 		}
@@ -136,10 +153,17 @@ func (e *Extractor) extractTables(database string) (err error) {
 	for rows.Next() {
 		var createdOn, name, databaseName, schemaName, kind, comment, clusterBy, owner, autoClustering, changeTracking, isExternal string
 		var bytes, rowsCount, retentionTime int
+		var x, y, z sql.RawBytes
 
 		if err = rows.Scan(&createdOn, &name, &databaseName, &schemaName, &kind, &comment, &clusterBy, &rowsCount,
-			&bytes, &owner, &retentionTime, &autoClustering, &changeTracking, &isExternal); err != nil {
+			&bytes, &owner, &retentionTime, &autoClustering, &changeTracking, &isExternal, &x, &y, &z); err != nil {
 			return err
+		}
+
+		// skip excluded tables
+		TableName := fmt.Sprintf("%s.%s", database, name)
+		if e.excludedTbl[TableName] {
+			continue
 		}
 		if err = e.processTable(database, name); err != nil {
 			return err


### PR DESCRIPTION
Adding option to exclude resources from being crawled from extractors
- [x] MongoDB 
- [x] CouchDB
- [x] MySQL
- [x] MsSQL
- [x] Snowflake (TODO: edit testcases)
- [x] Presto
- [x] MariaDB
- [x] GCS
- [x] Cassandra
- [x] Clickhouse
- [x] Grafana

**Note**: Metabase and Snowflake API responses have changed and the meteor extractors needs to be edited to support different versions